### PR TITLE
Override opt dir lintian errors with custom td-agent-builder profile

### DIFF
--- a/lib/apt/build.sh
+++ b/lib/apt/build.sh
@@ -69,11 +69,14 @@ elif [ -d "/host/tmp/debian.${platform}" ]; then
 else
   run cp -rp "/host/tmp/debian" debian
 fi
+# setup lintian profile
+run mkdir -p ~/.lintian/profiles/td-agent/
+run cp "/host/tmp/debian/lintian/td-agent/${distribution}.profile" ~/.lintian/profiles/td-agent/${distribution}.profile
 # export DEB_BUILD_OPTIONS=noopt
 if [ "${DEBUG:-no}" = "yes" ]; then
-  run debuild -us -uc
+  run debuild -us -uc --lintian-opts td-agent/${distribution}
 else
-  run debuild -us -uc > /dev/null
+  run debuild -us -uc --lintian-opts td-agent/${distribution} > /dev/null
 fi
 run cd -
 

--- a/td-agent/debian/lintian/td-agent/debian.profile
+++ b/td-agent/debian/lintian/td-agent/debian.profile
@@ -1,0 +1,3 @@
+Profile: td-agent/main
+Extends: debian/main
+Disable-Tags: dir-or-file-in-opt


### PR DESCRIPTION
Related to #4.
I didn't create custom lintian profile for Ubuntu but this script also considers for it.

`td-agent/debian/lintian/td-agent/ubuntu.profile` should be used in Ubuntu docker build environment.