### PR TITLE
Add CentOS 6 Dockerfile

### DIFF
--- a/td-agent/yum/centos-6/Dockerfile
+++ b/td-agent/yum/centos-6/Dockerfile
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG FROM=centos:6
+FROM ${FROM}
+
+COPY qemu-* /usr/bin/
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  yum update -y ${quiet} && \
+  yum install -y ${quiet} epel-release centos-release-scl && \
+  yum groupinstall -y ${quiet} "Development Tools" && \
+  yum install -y ${quiet} \
+    rh-ruby24-ruby-devel  \
+    rh-ruby24-rubygems \
+    rh-ruby24-rubygem-rake \
+    rh-ruby24-rubygem-bundler \
+    jemalloc-devel \
+    git \
+    libzstd-devel \
+    lz4-devel \
+    pkg-config \
+    rpm-build \
+    rpmdevtools \
+    openssl-devel \
+    tar \
+    zlib-devel && \
+  yum clean ${quiet} all

--- a/td-agent/yum/centos-6/qemu-dummy-static
+++ b/td-agent/yum/centos-6/qemu-dummy-static
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Do nothing. This exists only for not requiring qemu-aarch64-static copy.
+# Recent Debian (buster or later) and Ubuntu (18.10 or later) on amd64 hosts or
+# arm64 host don't require qemu-aarch64-static in Docker image. But old Debian
+# and Ubuntu hosts on amd64 require qemu-aarch64-static in Docker image.
+#
+# We use "COPY qemu* /usr/bin/" in Dockerfile. If we don't put any "qemnu*",
+# the "COPY" is failed. It means that we always require "qemu*" even if we
+# use recent Debian/Ubuntu or arm64 host. If we have this dummy "qemu*" file,
+# the "COPY" isn't failed. It means that we can copy "qemu*" only when we
+# need.
+#
+# See also "script" in dev/tasks/linux-packages/azure.linux.arm64.yml.
+# Azure Pipelines uses old Ubuntu (18.04).
+# So we need to put "qemu-aarch64-static" into this directory.


### PR DESCRIPTION
CentOS 6 doesn't support armv8.
So, we needn't prepare armv8/centos:6 Dockerfile.

Follows up #19.

Sorry, I'd forgotten to add Dockerfile which is used on CentOS 6 package building.... :cold_sweat: