### PR TITLE
Revert "RPM: Add missing dependencies"

### DIFF
--- a/td-agent/yum/td-agent.spec.in
+++ b/td-agent/yum/td-agent.spec.in
@@ -54,11 +54,6 @@ BuildRequires: systemd
 Requires: redhat-lsb-core
 %endif
 Requires(pre): /usr/bin/getent, /usr/sbin/adduser
-Requires: jemalloc
-Requires: libzstd
-Requires: lz4
-Requires: zlib
-Requires: openssl
 
 
 %description


### PR DESCRIPTION
Reverts clear-code/td-agent-builder#25

It's my misuderstanding,  dependencies are automatically resolved.
I just forgot to enable EPEL:

$ sudo dnf install epel-release -y
