### PR TITLE
Bundle jemalloc

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -70,12 +70,14 @@ end
 class DownloadTask
   include Rake::DSL
 
+  attr_reader :file_jemalloc_source
   attr_reader :file_ruby_source, :file_ruby_installer_x64
   attr_reader :file_fluentd_archive
   attr_reader :files_core_gems, :files_plugin_gems
 
   def files
     [
+      @file_jemalloc_source,
       @file_ruby_source,
       @file_ruby_installer_x64,
       @file_fluentd_archive,
@@ -85,12 +87,16 @@ class DownloadTask
   end
 
   def define
+    define_jemalloc_file
     define_ruby_files
     define_fluentd_archive
     define_gem_files("core_gems")
     define_gem_files("plugin_gems")
 
     namespace :download do
+      desc "Download jemalloc source"
+      task :jemalloc => [@file_jemalloc_source]
+
       desc "Download Ruby source"
       task :ruby => [@file_ruby_source, @file_ruby_installer_x64]
 
@@ -130,6 +136,17 @@ class DownloadTask
       end
 
       mv(tmp_filename, filename)
+    end
+  end
+
+  def define_jemalloc_file
+    version = JEMALLOC_VERSION
+    filename = "jemalloc-#{version}.tar.bz2"
+    url_base = "https://github.com/jemalloc/jemalloc/releases/download/"
+    @file_jemalloc_source = File.join(DOWNLOADS_DIR, filename)
+    file @file_jemalloc_source do
+      url = "#{url_base}/#{version}/#{filename}"
+      download_file(url, filename)
     end
   end
 
@@ -227,8 +244,13 @@ class BuildTask
 
   def define
     namespace :build do
+      desc "Install jemalloc"
+      task :jemalloc => [:"download:jemalloc"] do
+        build_jemalloc unless windows?
+      end
+
       desc "Install Ruby"
-      task :ruby => [:"download:ruby"] do
+      task :ruby => [:jemalloc, :"download:ruby"] do
         if windows?
           extract_ruby_installer
           setup_windows_build_env
@@ -441,6 +463,21 @@ class BuildTask
     end
   end
 
+  def build_jemalloc
+    tarball = @download_task.file_jemalloc_source
+    source_dir = tarball.sub(/\.tar\.bz2$/, '')
+
+    sh("tar", "xvf", tarball, "-C", DOWNLOADS_DIR)
+
+    configure_opts = [
+      "--prefix=#{install_prefix}",
+    ]
+    cd(source_dir) do
+      sh("./configure", *configure_opts)
+      sh("make", "install", "-j#{Etc.nprocessors}", "DESTDIR=#{STAGING_DIR}")
+    end
+  end
+
   def build_ruby_from_source
     tarball = @download_task.file_ruby_source
     ruby_source_dir = tarball.sub(/\.tar\.gz$/, '')
@@ -449,13 +486,12 @@ class BuildTask
 
     configure_opts = [
       "--prefix=#{install_prefix}",
-      "--with-jemalloc",
       "--enable-shared",
       "--disable-install-doc",
     ]
     cd(ruby_source_dir) do
       apply_ruby_patches
-      sh("./configure #{configure_opts.join(' ')}")
+      sh("./configure", *configure_opts)
       sh("make", "install", "-j#{Etc.nprocessors}", "DESTDIR=#{STAGING_DIR}")
 
       # For building gems. The built ruby & gem command cannot use without install.

--- a/td-agent/apt/debian-buster/Dockerfile
+++ b/td-agent/apt/debian-buster/Dockerfile
@@ -39,7 +39,6 @@ RUN \
     devscripts \
     ruby-dev \
     ruby-bundler \
-    libjemalloc-dev \
     git \
     libzstd-dev \
     liblz4-dev \

--- a/td-agent/apt/ubuntu-bionic/Dockerfile
+++ b/td-agent/apt/ubuntu-bionic/Dockerfile
@@ -38,7 +38,6 @@ RUN \
     devscripts \
     ruby-dev \
     ruby-bundler \
-    libjemalloc-dev \
     git \
     libzstd-dev \
     liblz4-dev \

--- a/td-agent/apt/ubuntu-focal/Dockerfile
+++ b/td-agent/apt/ubuntu-focal/Dockerfile
@@ -38,7 +38,6 @@ RUN \
     devscripts \
     ruby-dev \
     ruby-bundler \
-    libjemalloc-dev \
     git \
     libzstd-dev \
     liblz4-dev \

--- a/td-agent/config.rb
+++ b/td-agent/config.rb
@@ -3,6 +3,9 @@ PACKAGE_VERSION = "3.7.0"
 
 FLUENTD_REVISION = "7e3022efbb972d1a46fb66d1a6e2698abb46564e" # v1.10.0
 
+# https://github.com/jemalloc/jemalloc/releases/download/
+JEMALLOC_VERSION = "4.5.0"
+
 # https://www.ruby-lang.org/en/downloads/
 BUNDLED_RUBY_VERSION = "2.4.9"
 BUNDLED_RUBY_SOURCE_SHA256SUM = "f99b6b5e3aa53d579a49eb719dd0d3834d59124159a6d4351d1e039156b1c6ae"

--- a/td-agent/debian/control
+++ b/td-agent/debian/control
@@ -12,7 +12,6 @@ Build-Depends:
   ruby-dev,
   ruby-bundler,
   rake,
-  libjemalloc-dev,
   libzstd-dev,
   libssl-dev
 Standards-Version: 4.3.0

--- a/td-agent/templates/etc/init.d/td-agent.erb
+++ b/td-agent/templates/etc/init.d/td-agent.erb
@@ -161,6 +161,12 @@ if [ -n "${TD_AGENT_PID_FILE}" ]; then
   TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${TD_AGENT_PID_FILE}"
 fi
 
+# 2012/04/17 Kazuki Ohta <k@treasure-data.com>
+# Use jemalloc to avoid memory fragmentation
+if [ -f "${TD_AGENT_HOME}/lib/libjemalloc.so" ]; then
+  export LD_PRELOAD="${TD_AGENT_HOME}/lib/libjemalloc.so"
+fi
+
 kill_by_file() {
   local sig="$1"
   shift 1

--- a/td-agent/templates/etc/systemd/td-agent.service.erb
+++ b/td-agent/templates/etc/systemd/td-agent.service.erb
@@ -8,6 +8,7 @@ Wants=network-online.target
 User=<%= Shellwords.shellescape(project_name) %>
 Group=<%= Shellwords.shellescape(project_name) %>
 LimitNOFILE=65536
+Environment=LD_PRELOAD=<%= install_path %>/lib/libjemalloc.so
 Environment=GEM_HOME=<%= gem_install_path %>/
 Environment=GEM_PATH=<%= gem_install_path %>/
 Environment=FLUENT_CONF=/etc/<%= project_name %>/<%= project_name %>.conf

--- a/td-agent/yum/centos-6/Dockerfile
+++ b/td-agent/yum/centos-6/Dockerfile
@@ -32,7 +32,6 @@ RUN \
     rh-ruby24-rubygems \
     rh-ruby24-rubygem-rake \
     rh-ruby24-rubygem-bundler \
-    jemalloc-devel \
     git \
     libzstd-devel \
     lz4-devel \

--- a/td-agent/yum/centos-7/Dockerfile
+++ b/td-agent/yum/centos-7/Dockerfile
@@ -32,7 +32,6 @@ RUN \
     rh-ruby24-rubygems \
     rh-ruby24-rubygem-rake \
     rh-ruby24-rubygem-bundler \
-    jemalloc-devel \
     git \
     libzstd-devel \
     lz4-devel \

--- a/td-agent/yum/centos-8/Dockerfile
+++ b/td-agent/yum/centos-8/Dockerfile
@@ -32,7 +32,6 @@ RUN \
     rubygems \
     rubygem-rake \
     rubygem-bundler \
-    jemalloc-devel \
     git \
     libzstd-devel \
     lz4-devel \

--- a/td-agent/yum/td-agent.spec.in
+++ b/td-agent/yum/td-agent.spec.in
@@ -40,7 +40,6 @@ BuildRequires:	rubygems
 BuildRequires:	rubygem-bundler
 %endif
 BuildRequires:	gcc-c++
-BuildRequires:	jemalloc-devel
 BuildRequires:	git
 BuildRequires:	libzstd-devel
 BuildRequires:	lz4-devel


### PR DESCRIPTION
This commit discards "--with-jemalloc" option of Ruby, it seems hard to
use with libjemalloc in non-standard directory. Revive LD_PRELOAD
instead.

Fix #29

Signed-off-by: Takuro Ashie <ashie@clear-code.com>