### PR TITLE
yum: Add missing cyrus-sasl-devel and nss-softkn-freebl-devel build dependencies

### DIFF
--- a/td-agent/yum/centos-6/Dockerfile
+++ b/td-agent/yum/centos-6/Dockerfile
@@ -33,6 +33,8 @@ RUN \
     rh-ruby24-rubygem-rake \
     rh-ruby24-rubygem-bundler \
     git \
+    cyrus-sasl-devel \
+    nss-softokn-freebl-devel \
     libzstd-devel \
     lz4-devel \
     pkg-config \

--- a/td-agent/yum/centos-7/Dockerfile
+++ b/td-agent/yum/centos-7/Dockerfile
@@ -33,6 +33,8 @@ RUN \
     rh-ruby24-rubygem-rake \
     rh-ruby24-rubygem-bundler \
     git \
+    cyrus-sasl-devel \
+    nss-softokn-freebl-devel \
     libzstd-devel \
     lz4-devel \
     pkg-config \

--- a/td-agent/yum/centos-8/Dockerfile
+++ b/td-agent/yum/centos-8/Dockerfile
@@ -33,6 +33,8 @@ RUN \
     rubygem-rake \
     rubygem-bundler \
     git \
+    cyrus-sasl-devel \
+    nss-softokn-freebl-devel \
     libzstd-devel \
     lz4-devel \
     pkg-config \

--- a/td-agent/yum/td-agent.spec.in
+++ b/td-agent/yum/td-agent.spec.in
@@ -46,6 +46,8 @@ BuildRequires:	lz4-devel
 BuildRequires:	pkgconfig
 BuildRequires:	zlib-devel
 BuildRequires:	openssl-devel
+BuildRequires:	cyrus-sasl-devel
+BuildRequires:	nss-softokn-freebl-devel
 %if %{use_systemd}
 %{?systemd_requires}
 BuildRequires: systemd


### PR DESCRIPTION
Related to #31.

These are for libsasl2.so and libfreebl3.so.

CentOS 6 and 7 can handle linking libfreebl3 against librdkafka.so, but CnetOS 8 cannot handle it.
Should we fix ti?

### For CentOS 8

```
Installed:
  td-agent-3.7.0-1.el8.x86_64                                       libzstd-1.4.4-1.el8.x86_64                                      

Complete!
[vagrant@localhost Packages]$ ldd /opt/td-agent/lib/ruby/gems/2.4.0/gems/rdkafka-0.7.0/ext/librdkafka.so
/usr/bin/bash: warning: setlocale: LC_ALL: cannot change locale (ja_JP.UTF-8)
	linux-vdso.so.1 (0x00007ffc14fea000)
	liblz4.so.1 => /lib64/liblz4.so.1 (0x00007fb95c1ce000)
	libm.so.6 => /lib64/libm.so.6 (0x00007fb95be4c000)
	libzstd.so.1 => /lib64/libzstd.so.1 (0x00007fb95bba8000)
	libsasl2.so.3 => /lib64/libsasl2.so.3 (0x00007fb95b98a000)
	libssl.so.1.1 => /lib64/libssl.so.1.1 (0x00007fb95b6f7000)
	libcrypto.so.1.1 => /lib64/libcrypto.so.1.1 (0x00007fb95b21f000)
	libz.so.1 => /lib64/libz.so.1 (0x00007fb95b008000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007fb95ae04000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fb95abe4000)
	librt.so.1 => /lib64/librt.so.1 (0x00007fb95a9db000)
	libc.so.6 => /lib64/libc.so.6 (0x00007fb95a617000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fb95c6fd000)
	libresolv.so.2 => /lib64/libresolv.so.2 (0x00007fb95a400000)
	libcrypt.so.1 => /lib64/libcrypt.so.1 (0x00007fb95a1d7000)
	libgssapi_krb5.so.2 => /lib64/libgssapi_krb5.so.2 (0x00007fb959f87000)
	libkrb5.so.3 => /lib64/libkrb5.so.3 (0x00007fb959c97000)
	libk5crypto.so.3 => /lib64/libk5crypto.so.3 (0x00007fb959a7b000)
	libcom_err.so.2 => /lib64/libcom_err.so.2 (0x00007fb959877000)
	libkrb5support.so.0 => /lib64/libkrb5support.so.0 (0x00007fb959667000)
	libkeyutils.so.1 => /lib64/libkeyutils.so.1 (0x00007fb959463000)
	libselinux.so.1 => /lib64/libselinux.so.1 (0x00007fb959239000)
	libpcre2-8.so.0 => /lib64/libpcre2-8.so.0 (0x00007fb958fb5000)
```

### For CentOS 7

```
Installed:
  td-agent.x86_64 0:3.7.0-1.el7                                                                                                      

Dependency Installed:
  libzstd.x86_64 0:1.4.4-1.el7                   perl.x86_64 4:5.16.3-294.el7_6          perl-Carp.noarch 0:1.26-244.el7           
  perl-Encode.x86_64 0:2.51-7.el7                perl-Exporter.noarch 0:5.68-3.el7       perl-File-Path.noarch 0:2.09-2.el7        
  perl-File-Temp.noarch 0:0.23.01-3.el7          perl-Filter.x86_64 0:1.49-3.el7         perl-Getopt-Long.noarch 0:2.40-3.el7      
  perl-HTTP-Tiny.noarch 0:0.033-3.el7            perl-PathTools.x86_64 0:3.40-5.el7      perl-Pod-Escapes.noarch 1:1.04-294.el7_6  
  perl-Pod-Perldoc.noarch 0:3.20-4.el7           perl-Pod-Simple.noarch 1:3.28-4.el7     perl-Pod-Usage.noarch 0:1.63-3.el7        
  perl-Scalar-List-Utils.x86_64 0:1.27-248.el7   perl-Socket.x86_64 0:2.010-4.el7        perl-Storable.x86_64 0:2.45-3.el7         
  perl-Text-ParseWords.noarch 0:3.29-4.el7       perl-Time-HiRes.x86_64 4:1.9725-3.el7   perl-Time-Local.noarch 0:1.2300-2.el7     
  perl-constant.noarch 0:1.27-2.el7              perl-libs.x86_64 4:5.16.3-294.el7_6     perl-macros.x86_64 4:5.16.3-294.el7_6     
  perl-parent.noarch 1:0.225-244.el7             perl-podlators.noarch 0:2.5.1-3.el7     perl-threads.x86_64 0:1.87-4.el7          
  perl-threads-shared.x86_64 0:1.43-6.el7       

Complete!
[vagrant@localhost Packages]$ ldd /opt/td-agent/lib/ruby/gems/2.4.0/gems/rdkafka-0.7.0/ext/librdkafka.so
/usr/bin/bash: warning: setlocale: LC_ALL: cannot change locale (ja_JP.UTF-8)
	linux-vdso.so.1 =>  (0x00007ffdb1fc2000)
	liblz4.so.1 => /lib64/liblz4.so.1 (0x00007f5919092000)
	libm.so.6 => /lib64/libm.so.6 (0x00007f5918d90000)
	libzstd.so.1 => /lib64/libzstd.so.1 (0x00007f5918aec000)
	libsasl2.so.3 => /lib64/libsasl2.so.3 (0x00007f59188cf000)
	libssl.so.10 => /lib64/libssl.so.10 (0x00007f591865d000)
	libcrypto.so.10 => /lib64/libcrypto.so.10 (0x00007f59181fb000)
	libz.so.1 => /lib64/libz.so.1 (0x00007f5917fe5000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007f5917de1000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f5917bc5000)
	librt.so.1 => /lib64/librt.so.1 (0x00007f59179bd000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f59175f0000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f59195bf000)
	libresolv.so.2 => /lib64/libresolv.so.2 (0x00007f59173d7000)
	libcrypt.so.1 => /lib64/libcrypt.so.1 (0x00007f59171a0000)
	libgssapi_krb5.so.2 => /lib64/libgssapi_krb5.so.2 (0x00007f5916f53000)
	libkrb5.so.3 => /lib64/libkrb5.so.3 (0x00007f5916c6a000)
	libk5crypto.so.3 => /lib64/libk5crypto.so.3 (0x00007f5916a37000)
	libcom_err.so.2 => /lib64/libcom_err.so.2 (0x00007f5916833000)
	libkrb5support.so.0 => /lib64/libkrb5support.so.0 (0x00007f5916623000)
	libfreebl3.so => /lib64/libfreebl3.so (0x00007f5916420000)
	libkeyutils.so.1 => /lib64/libkeyutils.so.1 (0x00007f591621c000)
	libselinux.so.1 => /lib64/libselinux.so.1 (0x00007f5915ff5000)
	libpcre.so.1 => /lib64/libpcre.so.1 (0x00007f5915d93000)
```

### For CentOS 6

```
  td-agent.x86_64 0:3.7.0-1.el6                                                                                                      

依存性関連をインストールしました:
  cvs.x86_64 0:1.11.23-16.el6                                      db4-cxx.x86_64 0:4.7.25-22.el6                                    
  db4-devel.x86_64 0:4.7.25-22.el6                                 gdbm-devel.x86_64 0:1.8.0-39.el6                                  
  gettext.x86_64 0:0.17-18.el6                                     glibc-devel.x86_64 0:2.12-1.212.el6_10.3                          
  glibc-headers.x86_64 0:2.12-1.212.el6_10.3                       kernel-headers.x86_64 0:2.6.32-754.28.1.el6                       
  libgomp.x86_64 0:4.4.7-23.el6                                    libzstd.x86_64 0:1.4.4-1.el6                                      
  lz4.x86_64 0:r131-1.el6                                          patch.x86_64 0:2.6-8.el6_9                                        
  pax.x86_64 0:3.4-10.1.el6                                        perl-CGI.x86_64 0:3.51-144.el6                                    
  perl-ExtUtils-MakeMaker.x86_64 0:6.55-144.el6                    perl-ExtUtils-ParseXS.x86_64 1:2.2003.0-144.el6                   
  perl-Test-Harness.x86_64 0:3.17-144.el6                          perl-Test-Simple.x86_64 0:0.92-144.el6                            
  perl-devel.x86_64 4:5.10.1-144.el6                               redhat-lsb-core.x86_64 0:4.0-7.el6.centos                         

完了しました!
[vagrant@localhost Packages]$ ldd /opt/td-agent/lib/ruby/gems/2.4.0/gems/rdkafka-0.7.0/ext/librdkafka.so
	linux-vdso.so.1 =>  (0x00007ffd87db4000)
	liblz4.so.1 => /usr/lib64/liblz4.so.1 (0x00007f956156b000)
	libm.so.6 => /lib64/libm.so.6 (0x00007f95612e7000)
	libzstd.so.1 => /usr/lib64/libzstd.so.1 (0x00007f9561052000)
	libsasl2.so.2 => /usr/lib64/libsasl2.so.2 (0x00007f9560e38000)
	libssl.so.10 => /usr/lib64/libssl.so.10 (0x00007f9560bcc000)
	libcrypto.so.10 => /usr/lib64/libcrypto.so.10 (0x00007f95607e6000)
	libz.so.1 => /lib64/libz.so.1 (0x00007f95605d0000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007f95603cc000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f95601ae000)
	librt.so.1 => /lib64/librt.so.1 (0x00007f955ffa6000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f955fc12000)
	/lib64/ld-linux-x86-64.so.2 (0x000055a7b9f9d000)
	libresolv.so.2 => /lib64/libresolv.so.2 (0x00007f955f9f7000)
	libcrypt.so.1 => /lib64/libcrypt.so.1 (0x00007f955f7c0000)
	libgssapi_krb5.so.2 => /lib64/libgssapi_krb5.so.2 (0x00007f955f57c000)
	libkrb5.so.3 => /lib64/libkrb5.so.3 (0x00007f955f294000)
	libcom_err.so.2 => /lib64/libcom_err.so.2 (0x00007f955f090000)
	libk5crypto.so.3 => /lib64/libk5crypto.so.3 (0x00007f955ee64000)
	libfreebl3.so => /lib64/libfreebl3.so (0x00007f955ec60000)
	libkrb5support.so.0 => /lib64/libkrb5support.so.0 (0x00007f955ea55000)
	libkeyutils.so.1 => /lib64/libkeyutils.so.1 (0x00007f955e852000)
	libselinux.so.1 => /lib64/libselinux.so.1 (0x00007f955e632000)
```