### PR TITLE
yum: Remove EPEL dependecies

### DIFF
--- a/td-agent/yum/centos-6/Dockerfile
+++ b/td-agent/yum/centos-6/Dockerfile
@@ -25,7 +25,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   yum update -y ${quiet} && \
-  yum install -y ${quiet} epel-release centos-release-scl && \
+  yum install -y ${quiet} centos-release-scl && \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     rh-ruby24-ruby-devel  \
@@ -35,8 +35,6 @@ RUN \
     git \
     cyrus-sasl-devel \
     nss-softokn-freebl-devel \
-    libzstd-devel \
-    lz4-devel \
     pkg-config \
     rpm-build \
     rpmdevtools \

--- a/td-agent/yum/centos-7/Dockerfile
+++ b/td-agent/yum/centos-7/Dockerfile
@@ -25,7 +25,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   yum update -y ${quiet} && \
-  yum install -y ${quiet} epel-release centos-release-scl && \
+  yum install -y ${quiet} centos-release-scl && \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     rh-ruby24-ruby-devel  \
@@ -35,8 +35,6 @@ RUN \
     git \
     cyrus-sasl-devel \
     nss-softokn-freebl-devel \
-    libzstd-devel \
-    lz4-devel \
     pkg-config \
     rpm-build \
     rpmdevtools \

--- a/td-agent/yum/centos-8/Dockerfile
+++ b/td-agent/yum/centos-8/Dockerfile
@@ -24,7 +24,6 @@ ARG DEBUG
 
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
-  dnf install -y ${quiet} epel-release && \
   dnf install --enablerepo=PowerTools -y ${quiet} \
     make \
     gcc-c++ \
@@ -35,8 +34,6 @@ RUN \
     git \
     cyrus-sasl-devel \
     nss-softokn-freebl-devel \
-    libzstd-devel \
-    lz4-devel \
     pkg-config \
     rpm-build \
     rpmdevtools \

--- a/td-agent/yum/td-agent.spec.in
+++ b/td-agent/yum/td-agent.spec.in
@@ -41,8 +41,6 @@ BuildRequires:	rubygem-bundler
 %endif
 BuildRequires:	gcc-c++
 BuildRequires:	git
-BuildRequires:	libzstd-devel
-BuildRequires:	lz4-devel
 BuildRequires:	pkgconfig
 BuildRequires:	zlib-devel
 BuildRequires:	openssl-devel


### PR DESCRIPTION
zstd and lz4 are provided from EPEL.

They should be removed from building environment and dependencies.

Related to https://github.com/clear-code/td-agent-builder/pull/24#issuecomment-614111428.