### PR TITLE
apt: Remove zstd and lz4 dependencies

### DIFF
--- a/td-agent/apt/debian-buster/Dockerfile
+++ b/td-agent/apt/debian-buster/Dockerfile
@@ -40,8 +40,6 @@ RUN \
     ruby-dev \
     ruby-bundler \
     git \
-    libzstd-dev \
-    liblz4-dev \
     pkg-config \
     libssl-dev \
     libpq-dev \

--- a/td-agent/apt/ubuntu-bionic/Dockerfile
+++ b/td-agent/apt/ubuntu-bionic/Dockerfile
@@ -39,8 +39,6 @@ RUN \
     ruby-dev \
     ruby-bundler \
     git \
-    libzstd-dev \
-    liblz4-dev \
     pkg-config \
     libssl-dev \
     libpq-dev \

--- a/td-agent/apt/ubuntu-focal/Dockerfile
+++ b/td-agent/apt/ubuntu-focal/Dockerfile
@@ -39,8 +39,6 @@ RUN \
     ruby-dev \
     ruby-bundler \
     git \
-    libzstd-dev \
-    liblz4-dev \
     pkg-config \
     libssl-dev \
     libpq-dev \

--- a/td-agent/debian/control
+++ b/td-agent/debian/control
@@ -7,12 +7,10 @@ Build-Depends:
   debhelper (>= 10),
   cdbs,
   pkg-config,
-  liblz4-dev,
   zlib1g-dev,
   ruby-dev,
   ruby-bundler,
   rake,
-  libzstd-dev,
   libssl-dev
 Standards-Version: 4.3.0
 Homepage: http://www.fluentd.org/


### PR DESCRIPTION
Related to #31.

We also should remove zstd and lz4 dependencies from apt platforms.