### PR TITLE
yum: Add more dpendent libraries

### DIFF
--- a/td-agent/yum/centos-6/Dockerfile
+++ b/td-agent/yum/centos-6/Dockerfile
@@ -32,6 +32,9 @@ RUN \
     rh-ruby24-rubygems \
     rh-ruby24-rubygem-rake \
     rh-ruby24-rubygem-bundler \
+    libedit-devel \
+    ncurses-devel \
+    libyaml-devel \
     git \
     cyrus-sasl-devel \
     nss-softokn-freebl-devel \

--- a/td-agent/yum/centos-7/Dockerfile
+++ b/td-agent/yum/centos-7/Dockerfile
@@ -32,6 +32,9 @@ RUN \
     rh-ruby24-rubygems \
     rh-ruby24-rubygem-rake \
     rh-ruby24-rubygem-bundler \
+    libedit-devel \
+    ncurses-devel \
+    libyaml-devel \
     git \
     cyrus-sasl-devel \
     nss-softokn-freebl-devel \

--- a/td-agent/yum/centos-8/Dockerfile
+++ b/td-agent/yum/centos-8/Dockerfile
@@ -31,6 +31,9 @@ RUN \
     rubygems \
     rubygem-rake \
     rubygem-bundler \
+    libedit-devel \
+    ncurses-devel \
+    libyaml-devel \
     git \
     cyrus-sasl-devel \
     nss-softokn-freebl-devel \

--- a/td-agent/yum/td-agent.spec.in
+++ b/td-agent/yum/td-agent.spec.in
@@ -46,6 +46,9 @@ BuildRequires:	zlib-devel
 BuildRequires:	openssl-devel
 BuildRequires:	cyrus-sasl-devel
 BuildRequires:	nss-softokn-freebl-devel
+BuildRequires:	libedit-devel
+BuildRequires:	ncurses-devel
+BuildRequires:	libyaml-devel
 %if %{use_systemd}
 %{?systemd_requires}
 BuildRequires: systemd


### PR DESCRIPTION
Related to #31.

* libedit
* libtinfo
* libyaml

libxml2 and liblzma shouldn't be needed. Because we don't bundle nokogiri gem.