### PR TITLE
deb: add missing extended-description

### DIFF
--- a/td-agent/debian/control
+++ b/td-agent/debian/control
@@ -25,3 +25,7 @@ Depends:
   ${misc:Depends},
   ${shlibs:Depends},
 Description: Treasure Agent: A data collector for Treasure Data
+ Treasure Agent is all in one package which contains Fluentd and
+ related gem packages.
+ .
+ It is installable alongside with system's gem packages separately.


### PR DESCRIPTION
It fixes E: td-agent: extended-description-is-empty
lintian error.