### PR TITLE
deb: set correct distribution in changelog

### DIFF
--- a/lib/apt/build.sh
+++ b/lib/apt/build.sh
@@ -75,7 +75,7 @@ run mkdir -p ~/.lintian/profiles/td-agent/
 run cp "debian/lintian/td-agent/${distribution}.profile" ~/.lintian/profiles/td-agent/${distribution}.profile
 # export DEB_BUILD_OPTIONS=noopt
 DISTRIBUTION=`lsb_release -c | cut -f2`
-sed -i'' -e "s/unstable/$DISTRIBUTION/" debian/changelog
+sed -i'' -E "s/^($PACKAGE \(\S+\)) unstable;/\1 $DISTRIBUTION;/g" debian/changelog
 if [ "${DEBUG:-no}" = "yes" ]; then
   run debuild -us -uc --lintian-opts --profile td-agent/${distribution}
 else

--- a/lib/apt/build.sh
+++ b/lib/apt/build.sh
@@ -74,6 +74,8 @@ fi
 run mkdir -p ~/.lintian/profiles/td-agent/
 run cp "debian/lintian/td-agent/${distribution}.profile" ~/.lintian/profiles/td-agent/${distribution}.profile
 # export DEB_BUILD_OPTIONS=noopt
+DISTRIBUTION=`lsb_release -c | cut -f2`
+sed -i'' -e "s/unstable/$DISTRIBUTION/" debian/changelog
 if [ "${DEBUG:-no}" = "yes" ]; then
   run debuild -us -uc --lintian-opts --profile td-agent/${distribution}
 else


### PR DESCRIPTION
It fixes E: td-agent changes: bad-distribution-in-changes-file
unstable lintian error.