### PR TITLE
deb: drop needless Build-Depends

### DIFF
--- a/td-agent/apt/debian-buster/Dockerfile
+++ b/td-agent/apt/debian-buster/Dockerfile
@@ -35,7 +35,6 @@ RUN \
   apt install -y -V ${quiet} \
     build-essential \
     debhelper \
-    cdbs \
     devscripts \
     ruby-dev \
     ruby-bundler \

--- a/td-agent/apt/ubuntu-bionic/Dockerfile
+++ b/td-agent/apt/ubuntu-bionic/Dockerfile
@@ -34,7 +34,6 @@ RUN \
   apt install -y -V ${quiet} \
     build-essential \
     debhelper \
-    cdbs \
     devscripts \
     ruby-dev \
     ruby-bundler \

--- a/td-agent/apt/ubuntu-focal/Dockerfile
+++ b/td-agent/apt/ubuntu-focal/Dockerfile
@@ -34,7 +34,6 @@ RUN \
   apt install -y -V ${quiet} \
     build-essential \
     debhelper \
-    cdbs \
     devscripts \
     ruby-dev \
     ruby-bundler \

--- a/td-agent/debian/control
+++ b/td-agent/debian/control
@@ -5,7 +5,6 @@ Maintainer: Fluentd developers <fluentd@googlegroups.com>
 Uploaders: HATAKE Hiroshi <hatake@clear-code.com>
 Build-Depends:
   debhelper (>= 10),
-  cdbs,
   pkg-config,
   zlib1g-dev,
   ruby-dev,


### PR DESCRIPTION
cdbs is not used in d/rules at all.
It fixes W: td-agent source: unused-build-dependency-on-cdbs

NOTE: cdbs is referenced from autotools indirectly,
(td-agent itself does not depends it directly)
So, cdbs is only still listed in Dockerfile.