### PR TITLE
deb: fix td-agent tmp files handling in postinst

### DIFF
--- a/td-agent/debian/td-agent.lintian-overrides
+++ b/td-agent/debian/td-agent.lintian-overrides
@@ -13,3 +13,4 @@ td-agent: wrong-path-for-interpreter
 td-agent: duplicate-font-file
 td-agent: jar-not-in-usr-share
 td-agent: incorrect-libdir-in-la-file
+td-agent: possibly-insecure-handling-of-tmp-files-in-maintainer-script


### PR DESCRIPTION
It is false posivive because of /tmp/td-agent is
accessed by only td-agent:td-agent user/group.