### PR TITLE
deb: don't use recursive chown

### DIFF
--- a/td-agent/debian/td-agent.lintian-overrides
+++ b/td-agent/debian/td-agent.lintian-overrides
@@ -14,3 +14,4 @@ td-agent: duplicate-font-file
 td-agent: jar-not-in-usr-share
 td-agent: incorrect-libdir-in-la-file
 td-agent: possibly-insecure-handling-of-tmp-files-in-maintainer-script
+td-agent: maintainer-script-should-not-use-recursive-chown-or-chmod


### PR DESCRIPTION
It fixes W: maintainer-script-should-not-use-recursive-chown-or-chmod.
In postinst script, permission should be changed explicitly
to mitigate hardlink attacks.