### PR TITLE
deb: fix package-has-unnecessary-activation-of-ldconfig-trigger

### DIFF
--- a/td-agent/debian/rules
+++ b/td-agent/debian/rules
@@ -6,6 +6,9 @@ export DH_RUBY = --gem-install
 %:
 	dh $@
 
+override_dh_makeshlibs:
+	:
+
 override_dh_auto_install:
 	rake build:deb_config TD_AGENT_STAGING_PATH="$(CURDIR)/debian/tmp"
 	rake build:all        TD_AGENT_STAGING_PATH="$(CURDIR)/debian/tmp"


### PR DESCRIPTION
dh_makeshlibs kicks unnecessary ldconfig triggers, so
it is suppressed by override_dh_makeshlibs.