### PR TITLE
RPM: Build debuginfo package to strip executables

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -488,6 +488,7 @@ class BuildTask
       "--prefix=#{install_prefix}",
       "--enable-shared",
       "--disable-install-doc",
+      "--with-compress-debug-sections=no", # https://bugs.ruby-lang.org/issues/12934
     ]
     cd(ruby_source_dir) do
       apply_ruby_patches

--- a/td-agent/yum/centos-6/Dockerfile
+++ b/td-agent/yum/centos-6/Dockerfile
@@ -41,6 +41,7 @@ RUN \
     pkg-config \
     rpm-build \
     rpmdevtools \
+    redhat-rpm-config \
     openssl-devel \
     tar \
     zlib-devel && \

--- a/td-agent/yum/centos-7/Dockerfile
+++ b/td-agent/yum/centos-7/Dockerfile
@@ -41,6 +41,7 @@ RUN \
     pkg-config \
     rpm-build \
     rpmdevtools \
+    redhat-rpm-config \
     openssl-devel \
     tar \
     zlib-devel && \

--- a/td-agent/yum/centos-8/Dockerfile
+++ b/td-agent/yum/centos-8/Dockerfile
@@ -40,6 +40,7 @@ RUN \
     pkg-config \
     rpm-build \
     rpmdevtools \
+    redhat-rpm-config \
     openssl-devel \
     tar \
     zlib-devel && \

--- a/td-agent/yum/td-agent.spec.in
+++ b/td-agent/yum/td-agent.spec.in
@@ -20,6 +20,9 @@
 %define _centos_ver %{?centos_ver:%{centos_ver}}%{!?centos_ver:8}
 %define use_scl_ruby (%{_centos_ver} <= 7)
 %define use_systemd (%{_centos_ver} >= 7)
+# Omit check-rpath and brp-mangle-shebangs since we use our own Ruby
+%define __arch_install_post %{nil}
+%undefine __brp_mangle_shebangs
 
 Name:		@PACKAGE@
 Version:	@VERSION@
@@ -65,6 +68,8 @@ The stable distribution of Fluentd, called td-agent.
 %setup -q -n @PACKAGE@-%{version}
 
 %build
+
+%install
 %if %{use_scl_ruby}
 . /opt/rh/rh-ruby24/enable
 %endif


### PR DESCRIPTION
refs:
* https://github.com/clear-code/td-agent-builder/issues/44
* https://fedoraproject.org/wiki/Packaging:Debuginfo
* https://bugs.ruby-lang.org/issues/12934
* https://docs.fedoraproject.org/en-US/packaging-guidelines/#_beware_of_rpath
* https://fedoraproject.org/wiki/Changes/Make_ambiguous_python_shebangs_error

Signed-off-by: Takuro Ashie <ashie@clear-code.com>