### PR TITLE
deb: suppress W: incorrect-path-for-interpreter

### DIFF
--- a/td-agent/debian/td-agent.lintian-overrides
+++ b/td-agent/debian/td-agent.lintian-overrides
@@ -18,3 +18,4 @@ td-agent: maintainer-script-should-not-use-recursive-chown-or-chmod
 td-agent: unusual-interpreter opt/td-agent/lib/ruby/gems/*/gems/bundler-*/lib/bundler/templates/Executable #!<%=
 td-agent: unusual-interpreter opt/td-agent/lib/ruby/gems/*/gems/bundler-*/lib/bundler/templates/Executable.bundler #!<%=
 td-agent: unusual-interpreter opt/td-agent/lib/ruby/gems/*/gems/bundler-*/lib/bundler/templates/Executable.standalone #!<%=
+td-agent: incorrect-path-for-interpreter opt/td-agent/bin/jeprof (#!/usr/bin/env perl != /usr/bin/perl)


### PR DESCRIPTION
ref. https://www.debian.org/doc/debian-policy/ch-files.html#scripts
It should be fixed in jemalloc upstream.