### PR TITLE
deb: add missing copyright

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -26,6 +26,7 @@ require 'pathname'
 require 'open-uri'
 require 'digest'
 require 'etc'
+require "yaml"
 
 DOWNLOADS_DIR  = File.expand_path(ENV["TD_AGENT_DOWNLOADS_PATH"] || "downloads")
 STAGING_DIR    = File.expand_path(ENV["TD_AGENT_STAGING_PATH"]   || "staging")
@@ -685,8 +686,56 @@ class LinuxPackageTask < PackageTask
       File.join("..", path)
     end
 
-    file @archive_name => [*repo_files, *@download_task.files]  do
+    debian_copyright_file = File.join("td-agent", "debian", "copyright")
+    file debian_copyright_file do
+      build_copyright_file
+    end
+
+    file @archive_name => [*repo_files, *@download_task.files, debian_copyright_file]  do
       build_archive
+    end
+  end
+
+  def build_copyright_file
+    # Note: maintain debian/copyright manually is inappropriate way because
+    # many gem is bundled with td-agent package.
+    # We use gem specification GEMFILE to solve this issue.
+    src = File.join("templates", "package-scripts", "td-agent", "deb", "copyright")
+    dest = File.join("debian", "copyright")
+    licenses = []
+    template = File.open(src) do |infile|
+      infile.read
+    end
+    @download_task.files_core_gems.concat(@download_task.files_plugin_gems).each do |gem_file|
+      spec = YAML.load(`gem specification #{gem_file}`)
+      relative_path = gem_file.sub(/#{Dir.pwd}\//, "")
+      unless spec.licenses.empty?
+        license = <<-EOS
+Files: #{relative_path}
+Copyright: #{spec.authors.join(",")}
+License: #{spec.licenses.first.sub(/Apache 2.0/, "Apache-2.0")}
+EOS
+        licenses << license
+      else
+        # Note: remove this conditions when gem.licenses in gemspec was fixed in upstream
+        case spec.name
+        when "cool.io", "async-pool"
+          license = "MIT"
+
+        when "td", "webhdfs"
+          license = "Apache-2.0"
+        end
+        licenses <<= <<-EOS
+Files: #{relative_path}
+Copyright: #{spec.authors.join(",")}
+License: #{license}
+EOS
+      end
+    end
+    puts "Generate #{dest}"
+    File.open(dest, 'w+', 0644) do |f|
+      template.sub!(/BUNDLED_GEM_LICENSES/, licenses.join("\n"))
+      f.write(template)
     end
   end
 
@@ -705,6 +754,7 @@ class LinuxPackageTask < PackageTask
         ensure_directory(dest_dir)
         cp_r(path, dest_dir)
       end
+      cp_r("td-agent/debian/copyright", "#{@archive_base_name}/td-agent/debian/copyright")
       sh("tar", "cvfz", @full_archive_name, @archive_base_name)
       rm_rf(@archive_base_name)
     end

--- a/td-agent/templates/package-scripts/td-agent/deb/copyright
+++ b/td-agent/templates/package-scripts/td-agent/deb/copyright
@@ -1,0 +1,135 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: Treasure Data Agent
+
+Files: *
+Copyright: 2019-2020 Treasure Data, Inc.
+License: Apache-2.0
+
+Files: td-agent/downloads/ruby-2.4.10.tar.gz
+Copyright: Yukihiro Matsumoto <matz@netlab.jp> and others
+License: BSD-2-clause or Ruby
+
+BUNDLED_GEM_LICENSES
+
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+    https://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ .
+ On Debian-based systems the full text of the Apache version 2.0 license
+ can be found in /usr/share/common-licenses/Apache-2.0.
+ .
+ Note that td-agent package bundles many third-party software under
+ /opt/td-agent/embedded not to affect already installed packages.
+ See /opt/td-agent/LICENSE/* for embedded software.
+
+Files: td-agent/downloads/ruby-2.4.10.tar.gz
+Copyright: Yukihiro Matsumoto <matz@netlab.jp> and others
+License: BSD-2-clause or Ruby
+
+License: BSD-2-clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ SUCH DAMAGE.
+
+License: Ruby
+ Ruby is copyrighted free software by Yukihiro Matsumoto <matz@netlab.jp>.  You
+ can redistribute it and/or modify it under either the terms of the 2-clause
+ BSDL (see the file BSDL), or the conditions below:
+ .
+  1. You may make and give away verbatim copies of the source form of the
+     software without restriction, provided that you duplicate all of the
+     original copyright notices and associated disclaimers.
+ .
+ 2. You may modify your copy of the software in any way, provided that
+     you do at least ONE of the following:
+ .
+       a) place your modifications in the Public Domain or otherwise
+          make them Freely Available, such as by posting said
+          modifications to Usenet or an equivalent medium, or by allowing
+          the author to include your modifications in the software.
+ .
+       b) use the modified software only within your corporation or
+          organization.
+ .
+       c) give non-standard binaries non-standard names, with
+          instructions on where to get the original software distribution.
+ .
+       d) make other distribution arrangements with the author.
+ .
+ 3. You may distribute the software in object code or binary form,
+     provided that you do at least ONE of the following:
+ .
+       a) distribute the binaries and library files of the software,
+          together with instructions (in the manual page or equivalent)
+          on where to get the original distribution.
+ .
+       b) accompany the distribution with the machine-readable source of
+          the software.
+ .
+       c) give non-standard binaries non-standard names, with
+          instructions on where to get the original software distribution.
+ .
+       d) make other distribution arrangements with the author.
+ .
+ 4. You may modify and include the part of the software into any other
+     software (possibly commercial).  But some files in the distribution
+     are not written by the author, so that they are not under these terms.
+ .
+     For the list of those files and their copying conditions, see the
+     file LEGAL.
+ .
+  5. The scripts and library files supplied as input to or produced as
+     output from the software do not automatically fall under the
+     copyright of the software, but belong to whomever generated them,
+     and may be sold commercially, and may be aggregated with this
+     software.
+ .
+  6. THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+     IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+     PURPOSE.
+
+License: MIT
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.


### PR DESCRIPTION
It follows https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
