### PR TITLE
deb: fix spdx incompatible license field

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -710,10 +710,12 @@ class LinuxPackageTask < PackageTask
       spec = YAML.load(`gem specification #{gem_file}`)
       relative_path = gem_file.sub(/#{Dir.pwd}\//, "")
       unless spec.licenses.empty?
+        spdx_compatible_license = spec.licenses.first.sub(/Apache 2\.0/, "Apache-2.0")
+                                    .sub(/Apache License Version 2\.0/, "Apache-2.0")
         license = <<-EOS
 Files: #{relative_path}
 Copyright: #{spec.authors.join(",")}
-License: #{spec.licenses.first.sub(/Apache 2.0/, "Apache-2.0")}
+License: #{spdx_compatible_license}
 EOS
         licenses << license
       else


### PR DESCRIPTION
This commit fixes the following lintian warning:

  W: td-agent source: missing-license-paragraph-in-dep5-copyright apache license version 2.0 (paragraph at line 128)
  W: td-agent source: space-in-std-shortname-in-dep5-copyright apache license version 2.0 (paragraph at line 128)

ref. https://spdx.org/licenses/