### PR TITLE
deb: remove needless .la files

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -664,6 +664,7 @@ class BuildTask
     Dir.glob("#{gem_staging_dir}/gems/*").each do |gem_dir|
       if File.exist?("#{gem_dir}/ext")
         rm_f(Dir.glob("#{gem_dir}/ext/**/*.o"))
+        rm_f(Dir.glob("#{gem_dir}/ext/**/*.la"))
       end
       rm_rf(["#{gem_dir}/test", "{gem_dir}/spec"])
     end

--- a/td-agent/debian/td-agent.lintian-overrides
+++ b/td-agent/debian/td-agent.lintian-overrides
@@ -12,7 +12,6 @@ td-agent: library-not-linked-against-libc
 td-agent: wrong-path-for-interpreter
 td-agent: duplicate-font-file
 td-agent: jar-not-in-usr-share
-td-agent: incorrect-libdir-in-la-file
 td-agent: possibly-insecure-handling-of-tmp-files-in-maintainer-script
 td-agent: maintainer-script-should-not-use-recursive-chown-or-chmod
 td-agent: unusual-interpreter opt/td-agent/lib/ruby/gems/*/gems/bundler-*/lib/bundler/templates/Executable #!<%=


### PR DESCRIPTION
It fixes E: td-agent: incorrect-libdir-in-la-file

No need to override td-agent: incorrect-libdir-in-la-file
in td-agent.lintian-override anymore.