### PR TITLE
deb: remove needless vcs control file

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -667,6 +667,7 @@ class BuildTask
         rm_f(Dir.glob("#{gem_dir}/ext/**/*.la"))
       end
       rm_rf(["#{gem_dir}/test", "{gem_dir}/spec"])
+      rm_rf(Dir.glob("#{gem_staging_dir}/**/\.git*"))
     end
   end
 end

--- a/td-agent/debian/td-agent.lintian-overrides
+++ b/td-agent/debian/td-agent.lintian-overrides
@@ -1,4 +1,3 @@
-td-agent: package-contains-vcs-control-file
 td-agent: windows-devel-file-in-package
 td-agent: dir-or-file-in-build-tree
 td-agent: ruby-script-but-no-ruby-dep


### PR DESCRIPTION
It fixes W: td-agent: package-contains-vcs-control-file lintian
warnings.

No need to override td-agent: package-contains-vcs-control-file
in td-agent.lintian-override anymore.