### PR TITLE
deb: remove unused override rule

### DIFF
--- a/td-agent/debian/td-agent.lintian-overrides
+++ b/td-agent/debian/td-agent.lintian-overrides
@@ -1,6 +1,5 @@
 td-agent: package-contains-vcs-control-file
 td-agent: windows-devel-file-in-package
-td-agent: dir-or-file-in-build-tree
 td-agent: ruby-script-but-no-ruby-dep
 td-agent: script-not-executable
 td-agent: python-script-but-no-python-dep


### PR DESCRIPTION
It seems that td-agent: dir-or-file-in-build-tree is not used.