### PR TITLE
Add arm64 support to ubuntu focal

### DIFF
--- a/td-agent/apt/ubuntu-focal-arm64/from
+++ b/td-agent/apt/ubuntu-focal-arm64/from
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+arm64v8/ubuntu:focal


### PR DESCRIPTION
I tested this patch with https://github.com/clear-code/td-agent-builder/pull/24 and build stops by lintian phase.
Does anyone check this patch?