### PR TITLE
deb: support to skip lintian

### DIFF
--- a/lib/apt/build.sh
+++ b/lib/apt/build.sh
@@ -80,13 +80,13 @@ if [ "${DEBUG:-no}" = "yes" ]; then
   if [ "${LINTIAN:-yes}" = "yes" ]; then
     run debuild -us -uc --lintian-opts --profile td-agent/${distribution}
   else
-    run debuild -us -uc --no-lintian
+    run debuild --no-lintian -us -uc
   fi
 else
   if [ "${LINTIAN:-yes}" = "yes" ]; then
     run debuild -us -uc --lintian-opts --profile td-agent/${distribution} > /dev/null
   else
-    run debuild -us -uc --no-lintian > /dev/null
+    run debuild --no-lintian -us -uc > /dev/null
   fi
 fi
 run cd -

--- a/lib/apt/build.sh
+++ b/lib/apt/build.sh
@@ -77,9 +77,17 @@ run cp "debian/lintian/td-agent/${distribution}.profile" ~/.lintian/profiles/td-
 DISTRIBUTION=`lsb_release -c | cut -f2`
 sed -i'' -E "s/^($PACKAGE \(\S+\)) unstable;/\1 $DISTRIBUTION;/g" debian/changelog
 if [ "${DEBUG:-no}" = "yes" ]; then
-  run debuild -us -uc --lintian-opts --profile td-agent/${distribution}
+  if [ "${LINTIAN:-yes}" = "yes" ]; then
+    run debuild -us -uc --lintian-opts --profile td-agent/${distribution}
+  else
+    run debuild -us -uc --no-lintian
+  fi
 else
-  run debuild -us -uc --lintian-opts --profile td-agent/${distribution} > /dev/null
+  if [ "${LINTIAN:-yes}" = "yes" ]; then
+    run debuild -us -uc --lintian-opts --profile td-agent/${distribution} > /dev/null
+  else
+    run debuild -us -uc --no-lintian > /dev/null
+  fi
 fi
 run cd -
 

--- a/lib/package-task.rb
+++ b/lib/package-task.rb
@@ -72,6 +72,10 @@ class PackageTask
     ENV["DEBUG"] != "no"
   end
 
+  def skip_lintian?
+    ENV["LINTIAN"] == "no"
+  end
+
   def git_directory?(directory)
     candidate_paths = [".git", "HEAD"]
     candidate_paths.any? do |candidate_path|
@@ -125,6 +129,9 @@ class PackageTask
     if debug_build?
       build_command_line.concat(["--build-arg", "DEBUG=yes"])
       run_command_line.concat(["--env", "DEBUG=yes"])
+    end
+    if skip_lintian?
+      run_command_line.concat(["--env", "LINTIAN=no"])
     end
     if File.exist?(File.join(id, "Dockerfile"))
       docker_context = id


### PR DESCRIPTION
There is a case that lintian check stalls on ubuntu focal
arm64. Until that issue is fixed, skip lintian check as
a workaround.

Closes: #66