### PR TITLE
rpm: fix licence field

### DIFF
--- a/td-agent/yum/td-agent.spec.in
+++ b/td-agent/yum/td-agent.spec.in
@@ -29,7 +29,7 @@ Version:	@VERSION@
 Release:	@RELEASE@%{?dist}
 Summary:	The stable distribution of Fluentd, called @PACKAGE@.
 
-License:	Apache-2.0
+License:	ASL 2.0
 URL:		https://www.treasuredata.com/
 Source0:	@PACKAGE@-@VERSION@.tar.gz
 


### PR DESCRIPTION
It should be ASL 2.0 instead of Apache-2.0

ref. https://fedoraproject.org/wiki/Licensing:Main?rd=Licensing#Software_License_List