### PR TITLE
Fix build error of winevt_c

### DIFF
--- a/td-agent/plugin_gems.rb
+++ b/td-agent/plugin_gems.rb
@@ -64,6 +64,6 @@ end
 download "fluent-plugin-td-monitoring", "0.2.4"
 if windows?
   download 'win32-eventlog', '0.6.7'
-  download 'winevt_c', '0.7.3'
+  download 'winevt_c', '0.7.4'
   download 'fluent-plugin-windows-eventlog', '0.5.4'
 end


### PR DESCRIPTION
Bump up the version to 0.7.4.
See also: https://github.com/fluent-plugins-nursery/winevt_c/pull/26

Fix #26