### PR TITLE
rpm: fix W: name-repeated-in-summary

### DIFF
--- a/td-agent/yum/td-agent.spec.in
+++ b/td-agent/yum/td-agent.spec.in
@@ -28,7 +28,7 @@
 Name:		@PACKAGE@
 Version:	@VERSION@
 Release:	@RELEASE@%{?dist}
-Summary:	The stable distribution of Fluentd, called @PACKAGE@.
+Summary:	The stable distribution of Fluentd
 
 License:	ASL 2.0
 URL:		https://www.treasuredata.com/


### PR DESCRIPTION
It seems that ", called td-agent" is redundant.

td-agent.x86_64: W: name-repeated-in-summary C td-agent
The name of the package is repeated in its summary.  This is often redundant
information and looks silly in various programs' output.  Make the summary
brief and to the point without including redundant information in it.
