### PR TITLE
rpm: Fix the wrong path of the logrotate config file

### DIFF
--- a/td-agent/yum/td-agent.spec.in
+++ b/td-agent/yum/td-agent.spec.in
@@ -102,7 +102,6 @@ fi
 %files
 %defattr(-,root,root,-)
 /opt/*
-%{_sysconfdir}/logrotate.d/@PACKAGE@.logrotate
 %{_sysconfdir}/@PACKAGE@/@PACKAGE@.conf.tmpl
 %if %{use_systemd}
 %{_unitdir}/@PACKAGE@.service


### PR DESCRIPTION
.logrotate suffix is removed at
8c9dc8d66080f6c77148fab49d0bebf8f2b867cf.

Signed-off-by: Takuro Ashie <ashie@clear-code.com>