### PR TITLE
rpm: remove needless static library

### DIFF
--- a/td-agent/Rakefile
+++ b/td-agent/Rakefile
@@ -695,6 +695,7 @@ class BuildTask
         remove_files("ext/**/*.{o,la,a}")
       end
     end
+    remove_files("#{td_agent_staging_dir}/lib/lib*.a")
   end
 end
 


### PR DESCRIPTION
It fixes:
  W: spurious-executable-perm /opt/td-agent/lib/libjemalloc.a
  W: spurious-executable-perm /opt/td-agent/lib/libjemalloc_pic.a