### PR TITLE
rpm: suppress error without ldconfig

### DIFF
--- a/td-agent/yum/rpmlint.config
+++ b/td-agent/yum/rpmlint.config
@@ -34,3 +34,6 @@ addFilter("E: use-tmp-in-%post")
 addFilter("W: dangerous-command-in-%preun rm")
 # It is intended to ignore tmpwatch workaround
 addFilter("W: dangerous-command-in-%post cp")
+# It is intended to ignore under /opt/td-agent for ld.so.cache
+addFilter("E: postin-without-ldconfig")
+addFilter("E: library-without-ldconfig-postun")


### PR DESCRIPTION
It is ok suppressing E: postin-without-ldconfig and E:
library-without-ldconfig-postun because /opt/td-agent was isolated
with packages which are installed to the system.