### PR TITLE
Run rpmlint on Amazon Linux 2

### DIFF
--- a/td-agent/yum/amazonlinux-2/Dockerfile
+++ b/td-agent/yum/amazonlinux-2/Dockerfile
@@ -39,7 +39,8 @@ RUN \
     redhat-rpm-config \
     openssl-devel \
     tar \
-    zlib-devel && \
+    zlib-devel \
+    rpmlint && \
   amazon-linux-extras install ruby2.6 && \
   gem install bundler && \
   yum clean ${quiet} all


### PR DESCRIPTION
Otherwise, executing rpmlint on Amazon Linux causes command not found error.